### PR TITLE
feat: お問い合わせフォームからプライバシーポリシー同意を削除

### DIFF
--- a/app/lib/translations.ts
+++ b/app/lib/translations.ts
@@ -423,18 +423,10 @@ export const translations = {
         jp: "現在の課題、関心のある製品、PoCで確認したいこと、技術的に相談したい点などをご記入ください。初回のお問い合わせでは、機微情報の記載は不要です。",
         en: "Tell us your current challenges, the products you are interested in, what you want to verify in a PoC, or any technical points you would like to discuss. For a first inquiry, no sensitive information is needed.",
       },
-      privacy: {
-        jp: "個人情報の取り扱いについて、プライバシーポリシーに同意します。",
-        en: "I agree to the handling of personal information in line with the Privacy Policy.",
-      },
-      privacyLink: {
-        jp: "プライバシーポリシー",
-        en: "Privacy Policy",
-      },
       submit: { jp: "送信する", en: "Send" },
       afterSubmit: {
-        jp: "お預かりした情報は当社のプライバシーポリシーに基づき取り扱います。",
-        en: "Submissions are handled in line with our Privacy Policy.",
+        jp: "ご記入の内容はお問い合わせ対応のみに使用し、第三者に提供することはありません。",
+        en: "The information you provide will be used solely to respond to your inquiry and will not be shared with third parties.",
       },
       sent: {
         jp: "送信ありがとうございます。担当者よりご連絡いたします。",
@@ -462,10 +454,6 @@ export const translations = {
         emailInvalid: {
           jp: "有効なメールアドレスを入力してください。",
           en: "Please enter a valid email address.",
-        },
-        privacyRequired: {
-          jp: "プライバシーポリシーへの同意が必要です。",
-          en: "You must agree to the privacy policy.",
         },
         submitFailed: {
           jp: "送信に失敗しました。しばらく経ってから再度お試しください。",

--- a/app/routes/contact/contact.schema.test.ts
+++ b/app/routes/contact/contact.schema.test.ts
@@ -13,7 +13,6 @@ const validInput = {
   role: "情報セキュリティ 部長",
   email: "taro@example.com",
   message: "PoCについて相談したいです。",
-  privacy: true,
 };
 
 describe("contactFormSchema", () => {
@@ -94,19 +93,6 @@ describe("contactFormSchema", () => {
     });
   });
 
-  describe("privacy", () => {
-    it("rejects when privacy is missing", () => {
-      const { privacy: _privacy, ...rest } = validInput;
-      const result = contactFormSchema.safeParse(rest);
-      expect(result.success).toBe(false);
-    });
-
-    it("rejects when privacy is false", () => {
-      const result = contactFormSchema.safeParse({ ...validInput, privacy: false });
-      expect(result.success).toBe(false);
-    });
-  });
-
   describe("enum validation", () => {
     it("rejects unknown kind", () => {
       const result = contactFormSchema.safeParse({ ...validInput, kind: "kindX" });
@@ -156,17 +142,6 @@ describe("contactFormSchema", () => {
         const jpEmail = jp.error.issues.find((i) => i.path[0] === "email");
         expect(enEmail?.message).toBe("Please enter a valid email address.");
         expect(jpEmail?.message).toBe("有効なメールアドレスを入力してください。");
-      }
-    });
-
-    it("privacy error is translated", () => {
-      const en = makeContactFormSchema("en").safeParse({ ...validInput, privacy: false });
-      const jp = makeContactFormSchema("jp").safeParse({ ...validInput, privacy: false });
-      if (!en.success && !jp.success) {
-        const enPrivacy = en.error.issues.find((i) => i.path[0] === "privacy");
-        const jpPrivacy = jp.error.issues.find((i) => i.path[0] === "privacy");
-        expect(enPrivacy?.message).toBe("You must agree to the privacy policy.");
-        expect(jpPrivacy?.message).toBe("プライバシーポリシーへの同意が必要です。");
       }
     });
   });

--- a/app/routes/contact/contact.schema.ts
+++ b/app/routes/contact/contact.schema.ts
@@ -27,7 +27,6 @@ export type ContactFormInput = {
   role: string;
   email: string;
   message: string;
-  privacy: boolean;
 };
 
 const REQUIRED = {
@@ -37,10 +36,6 @@ const REQUIRED = {
 const EMAIL_INVALID = {
   jp: "有効なメールアドレスを入力してください。",
   en: "Please enter a valid email address.",
-} as const;
-const PRIVACY_REQUIRED = {
-  jp: "プライバシーポリシーへの同意が必要です。",
-  en: "You must agree to the privacy policy.",
 } as const;
 
 export function makeContactFormSchema(lang: "jp" | "en") {
@@ -53,6 +48,5 @@ export function makeContactFormSchema(lang: "jp" | "en") {
     role: z.string(),
     email: z.email(EMAIL_INVALID[lang]),
     message: z.string().min(1, REQUIRED[lang]),
-    privacy: z.boolean().refine((v) => v === true, { message: PRIVACY_REQUIRED[lang] }),
   });
 }

--- a/app/routes/contact/contact.server.test.ts
+++ b/app/routes/contact/contact.server.test.ts
@@ -59,7 +59,6 @@ const validInput: ContactFormInput = {
   role: "情報セキュリティ 部長",
   email: "taro@example.com",
   message: "PoCについて相談したいです。",
-  privacy: true,
 };
 
 const fixedIsoNow = "2024-06-15T10:30:00.000Z";
@@ -73,9 +72,9 @@ function createMockAppendRow(): MockAppendRow {
 const defaultAppendResult: AppendRowResult = {
   spreadsheetId: "sheet-1",
   updatedRows: 1,
-  updatedColumns: 11,
-  updatedCells: 11,
-  updatedRange: "Form!A2:K2",
+  updatedColumns: 10,
+  updatedCells: 10,
+  updatedRange: "Form!A2:J2",
 };
 
 describe("submitContactForm", () => {
@@ -103,7 +102,7 @@ describe("submitContactForm", () => {
       expect(appendRowMock.mock.calls).toHaveLength(1);
 
       const callArg = appendRowMock.mock.calls[0]![0];
-      expect(callArg.range).toBe("Form!A:K");
+      expect(callArg.range).toBe("Form!A:J");
       expect(callArg.values).toHaveLength(1);
 
       const row = callArg.values[0]!;
@@ -117,7 +116,6 @@ describe("submitContactForm", () => {
       expect(row[7]).toBe("Pixie Defense Suite");
       expect(row[8]).toBe("重要業務停止リスクを把握したい / インシデント時の業務影響を整理したい");
       expect(row[9]).toBe("PoCについて相談したいです。");
-      expect(row[10]).toBe("agreed");
     });
 
     it("translates to English when lang=en", async () => {
@@ -178,13 +176,13 @@ describe("submitContactForm", () => {
   });
 
   describe("row column order", () => {
-    it("emits columns in the documented order [timestamp, lang, kind, name, org, role, email, product, topics, message, privacy]", async () => {
+    it("emits columns in the documented order [timestamp, lang, kind, name, org, role, email, product, topics, message]", async () => {
       const { deps, appendRowMock } = setup();
       await submitContactForm(validInput, deps);
       const row = appendRowMock.mock.calls[0]![0].values[0]!;
-      expect(row).toHaveLength(11);
+      expect(row).toHaveLength(10);
       expect(row[0]).toBe(fixedIsoNow);
-      expect(row[10]).toBe("agreed");
+      expect(row[9]).toBe(validInput.message);
     });
   });
 

--- a/app/routes/contact/contact.server.ts
+++ b/app/routes/contact/contact.server.ts
@@ -3,7 +3,7 @@ import { tr } from "~/lib/i18n";
 
 import type { ContactFormInput } from "./contact.schema";
 
-const SHEET_RANGE = "Form!A:K";
+export const SHEET_RANGE = "Form!A:J";
 
 export type SubmitDeps = {
   appendRow: AppendRowFn;
@@ -51,7 +51,6 @@ export async function submitContactForm(
     translateProduct(lang, input.product),
     translateTopics(lang, input.topics),
     input.message,
-    "agreed",
   ];
 
   try {

--- a/app/routes/contact/form.tsx
+++ b/app/routes/contact/form.tsx
@@ -21,7 +21,6 @@ const DEFAULT_VALUES: ContactFormInput = {
   role: "",
   email: "",
   message: "",
-  privacy: false,
 };
 
 function FieldLabel({
@@ -67,7 +66,6 @@ function buildFormData(value: ContactFormInput): FormData {
   fd.append("role", value.role);
   fd.append("email", value.email);
   fd.append("message", value.message);
-  if (value.privacy) fd.append("privacy", "on");
   return fd;
 }
 
@@ -409,60 +407,6 @@ export function ContactForm() {
                     className="border-line bg-paper-white text-fg w-full resize-y rounded-sm border px-3.5 py-3 font-sans text-[14px] leading-[1.6]"
                   />
                 </FieldLabel>
-              );
-            }}
-          />
-
-          <form.Field
-            name="privacy"
-            children={(field) => {
-              const err = field.state.meta.errors[0]?.message;
-              return (
-                <div className="mt-2 flex flex-col gap-1.5">
-                  <label className="flex cursor-pointer items-start gap-2.5">
-                    <input
-                      type="checkbox"
-                      name={field.name}
-                      checked={field.state.value}
-                      onBlur={field.handleBlur}
-                      onChange={(e) => field.handleChange(e.target.checked)}
-                      className="accent-shu mt-0.75 h-3.75 w-3.75 shrink-0 cursor-pointer"
-                    />
-                    <span className="text-ink-700 font-sans text-[13px] leading-[1.6]">
-                      {lang === "jp" ? (
-                        <>
-                          個人情報の取り扱いについて、{" "}
-                          <a
-                            href="#"
-                            className="text-fg underline"
-                          >
-                            {tr(lang, "contact.form.privacyLink")}
-                          </a>
-                          に同意します。
-                        </>
-                      ) : (
-                        <>
-                          I agree to the handling of personal information in line with the{" "}
-                          <a
-                            href="#"
-                            className="text-fg underline"
-                          >
-                            {tr(lang, "contact.form.privacyLink")}
-                          </a>
-                          .
-                        </>
-                      )}
-                    </span>
-                  </label>
-                  {err && (
-                    <span
-                      className="text-shu pl-6 font-sans text-[12px]"
-                      role="alert"
-                    >
-                      {err}
-                    </span>
-                  )}
-                </div>
               );
             }}
           />

--- a/app/routes/contact/route.test.ts
+++ b/app/routes/contact/route.test.ts
@@ -46,7 +46,6 @@ const validForm: Record<string, string> = {
   role: "情報セキュリティ 部長",
   email: "taro@example.com",
   message: "PoCについて相談したいです。",
-  privacy: "on",
 };
 
 async function makeKeyPairPem() {
@@ -70,7 +69,7 @@ describe("contact action", () => {
       private_key: privatePem,
     });
     envState.GOOGLE_SPREADSHEET_ID = "sheet-1";
-    envState.GOOGLE_SHEET_RANGE = "Form!A:K";
+    envState.GOOGLE_SHEET_RANGE = "Form!A:J";
     delete envState.ENVIRONMENT;
     mockedCreateClient.mockReset();
     consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -88,9 +87,9 @@ describe("contact action", () => {
         appendRow: vi.fn().mockResolvedValue({
           spreadsheetId: "sheet-1",
           updatedRows: 1,
-          updatedColumns: 11,
-          updatedCells: 11,
-          updatedRange: "Form!A2:K2",
+          updatedColumns: 10,
+          updatedCells: 10,
+          updatedRange: "Form!A2:J2",
         }),
       });
 
@@ -227,21 +226,6 @@ describe("contact action", () => {
   });
 
   describe("validation", () => {
-    it("returns { ok: false, error: required } when privacy is missing", async () => {
-      const form = { ...validForm };
-      delete form.privacy;
-
-      const result = await action({
-        request: buildRequest(form),
-      } as Parameters<typeof action>[0]);
-
-      expect(result).toEqual({
-        ok: false,
-        error: expect.stringMatching(/必須|required/i),
-      });
-      expect(mockedCreateClient).not.toHaveBeenCalled();
-    });
-
     it("returns { ok: false, error: required } when email is invalid", async () => {
       const result = await action({
         request: buildRequest({ ...validForm, email: "not-an-email" }),

--- a/app/routes/contact/route.tsx
+++ b/app/routes/contact/route.tsx
@@ -8,7 +8,7 @@ import type { Lang } from "~/lib/translations";
 
 import type { Route } from "./+types/route";
 import { makeContactFormSchema } from "./contact.schema";
-import { submitContactForm } from "./contact.server";
+import { SHEET_RANGE, submitContactForm } from "./contact.server";
 import { ContactForm } from "./form";
 import { ContactHero } from "./hero";
 
@@ -45,7 +45,6 @@ function parseFormData(formData: FormData) {
     role: formData.get("role") ?? "",
     email: formData.get("email") ?? "",
     message: formData.get("message") ?? "",
-    privacy: formData.get("privacy") === "on",
   };
 }
 
@@ -80,7 +79,7 @@ export async function action({ request }: Route.ActionArgs) {
 
     const rawKey = env.GOOGLE_SERVICE_ACCOUNT_KEY;
     const spreadsheetId = env.GOOGLE_SPREADSHEET_ID;
-    const range = env.GOOGLE_SHEET_RANGE ?? "Form!A:K";
+    const range = env.GOOGLE_SHEET_RANGE ?? SHEET_RANGE;
     if (!rawKey || !spreadsheetId) {
       console.error("[contact] Missing GOOGLE_SERVICE_ACCOUNT_KEY or GOOGLE_SPREADSHEET_ID");
       return {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,6 +7,6 @@
     "ENVIRONMENT": "production",
     "GOOGLE_SHEETS_ENABLED": "true",
     "GOOGLE_SPREADSHEET_ID": "PROD_SPREADSHEET_ID",
-    "GOOGLE_SHEET_RANGE": "Form!A:K"
-  }
+    "GOOGLE_SHEET_RANGE": "Form!A:J",
+  },
 }


### PR DESCRIPTION
- プライバシーポリシー同意チェックボックスと関連バリデーションを削除
- スプレッドシートのカラム範囲を A:K から A:J に変更
- 同意関連の翻訳キー・テストケースを削除
- afterSubmit の文言を同意ポリシー参照から用途説明に変更