### PR TITLE
chore: 製品名をリネーム

### DIFF
--- a/app/lib/translations.ts
+++ b/app/lib/translations.ts
@@ -186,7 +186,7 @@ export const translations = {
       },
       layersLabel: { jp: "対象領域", en: "Layers" },
       p1tag: { jp: "Product 01", en: "Product 01" },
-      p1name: { jp: "Pixie Defense Suite", en: "Pixie Defense Suite" },
+      p1name: { jp: "Pixie for Operations", en: "Pixie for Operations" },
       p1role: {
         jp: "重要業務停止リスクの対応基盤",
         en: "Response platform for critical-operation stoppage risk",
@@ -199,7 +199,7 @@ export const translations = {
         en: "Shows what would stop if a risk is left unaddressed, and what to defend first.",
       },
       p2tag: { jp: "Product 02", en: "Product 02" },
-      p2name: { jp: "Pixie Shield", en: "Pixie Shield" },
+      p2name: { jp: "Pixie for Code", en: "Pixie for Code" },
       p2role: {
         jp: "開発現場向けの脆弱性対応基盤",
         en: "Vulnerability response platform for development teams",
@@ -378,8 +378,6 @@ export const translations = {
         jp: "関心のある製品 · Product",
         en: "Product of interest",
       },
-      product1: { jp: "Pixie Defense Suite", en: "Pixie Defense Suite" },
-      product2: { jp: "Pixie Shield", en: "Pixie Shield" },
       product3: {
         jp: "まだ決まっていない / 相談しながら整理したい",
         en: "Not decided yet / want to figure it out together",

--- a/app/routes/contact/contact.server.test.ts
+++ b/app/routes/contact/contact.server.test.ts
@@ -14,8 +14,8 @@ vi.mock("~/lib/i18n", () => ({
       "contact.form.kind3": { jp: "導入について相談したい", en: "Talk about adoption" },
       "contact.form.kind4": { jp: "技術的な質問をしたい", en: "Ask a technical question" },
       "contact.form.kind5": { jp: "パートナー・協業・その他", en: "Partnership / other" },
-      "home.products.p1name": { jp: "Pixie Defense Suite", en: "Pixie Defense Suite" },
-      "home.products.p2name": { jp: "Pixie Shield", en: "Pixie Shield" },
+      "home.products.p1name": { jp: "Pixie for Operations", en: "Pixie for Operations" },
+      "home.products.p2name": { jp: "Pixie for Code", en: "Pixie for Code" },
       "contact.form.product3": {
         jp: "まだ決まっていない / 相談しながら整理したい",
         en: "Not decided / figure out through consultation",
@@ -113,7 +113,7 @@ describe("submitContactForm", () => {
       expect(row[4]).toBe("株式会社サンプル");
       expect(row[5]).toBe("情報セキュリティ 部長");
       expect(row[6]).toBe("taro@example.com");
-      expect(row[7]).toBe("Pixie Defense Suite");
+      expect(row[7]).toBe("Pixie for Operations");
       expect(row[8]).toBe("重要業務停止リスクを把握したい / インシデント時の業務影響を整理したい");
       expect(row[9]).toBe("PoCについて相談したいです。");
     });
@@ -126,7 +126,7 @@ describe("submitContactForm", () => {
       const row = appendRowMock.mock.calls[0]![0].values[0]!;
       expect(row[1]).toBe("en");
       expect(row[2]).toBe("Request a product demo");
-      expect(row[7]).toBe("Pixie Defense Suite");
+      expect(row[7]).toBe("Pixie for Operations");
       expect(row[8]).toBe(
         "Understand critical-operation stoppage risk / Map operational impact during an incident",
       );


### PR DESCRIPTION
Pixie Defense Suite → Pixie for Operations, Pixie Shield → Pixie for Code

製品ブランド方針の変更に伴う表示名の更新。
製品キー (p1name / p2name) は不変、表示文字列とテスト期待値のみ更新。

- home.products.p1name: Pixie Defense Suite → Pixie for Operations
- home.products.p2name: Pixie Shield → Pixie for Code
- contact.server.test.ts: 翻訳モック + assertion を新名に更新
- contact.form.product1 / product2: 未参照のため削除